### PR TITLE
fix: rename package / thread safety

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,3 +33,5 @@ jobs:
          version: ${{ matrix.version.golangci }}
       - name: Run tests
         run: make test
+      - name: Run benchmarks
+        run: make bench

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.2.0] - 2023-03-30
+
+### Changed
+
 - Readme updates.
 - `internal` package - has no change to library functionality.
 - Rename `maxTokens` to `max` when constructing new rate limiter.
+- Fine-grained locking for rate limiter.
+- Rename internal struct fields.
+- Rename package (it was wrongly packaged under ratelimiter)
+- Use nanosecnd precision for timestamps.
+
+### Fixed
+
+- Make rate limiter more thread safe. There was potential for race conditons prior to this.
 
 ## [0.1.0] - 2023-03-30
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test build lint fmt
+.PHONY: test bench build lint fmt
 
 lint := go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
 
@@ -22,3 +22,7 @@ lint:
 test:
 	@echo "Running tests..."
 	go test -v -race ./...
+
+bench:
+	@echo "Running benchmarks..."
+	go test -bench=. -count 5 -run=^# ./...

--- a/internal/bucket/bucket.go
+++ b/internal/bucket/bucket.go
@@ -1,9 +1,14 @@
 package bucket
 
+import (
+	"sync"
+)
+
 // Bucket represents a token bucket.
 //
-// It is not safe for concurrent use.
+// It is safe for concurrent use.
 type Bucket struct {
+	m sync.Mutex
 	// size is the max tokens the bucket can hold.
 	size uint64
 
@@ -16,6 +21,7 @@ type Bucket struct {
 // size number of max tokens.
 func New(size uint64) *Bucket {
 	return &Bucket{
+		m:         sync.Mutex{},
 		size:      size,
 		available: size,
 	}
@@ -34,6 +40,9 @@ func (b *Bucket) Take() bool {
 // If n tokens are not available, no tokens are removed
 // from the bucket.
 func (b *Bucket) TakeN(n uint64) bool {
+	b.m.Lock()
+	defer b.m.Unlock()
+
 	if b.available >= n {
 		b.available -= n
 		return true
@@ -47,6 +56,9 @@ func (b *Bucket) TakeN(n uint64) bool {
 // If the quantity to refill exceeds the size of the bucket,
 // the bucket is refilled upto its size.
 func (b *Bucket) Refill(n uint64) {
+	b.m.Lock()
+	defer b.m.Unlock()
+
 	t := b.available + n
 	if t > b.size {
 		t = b.size
@@ -56,10 +68,16 @@ func (b *Bucket) Refill(n uint64) {
 
 // Available returns the tokens currently available in the bucket.
 func (b *Bucket) Available() uint64 {
+	b.m.Lock()
+	defer b.m.Unlock()
+
 	return b.available
 }
 
 // Size returns the max tokens a bucket can have.
 func (b *Bucket) Size() uint64 {
+	b.m.Lock()
+	defer b.m.Unlock()
+
 	return b.size
 }

--- a/internal/bucket/bucket_test.go
+++ b/internal/bucket/bucket_test.go
@@ -35,3 +35,12 @@ func TestBucket_Refill(t *testing.T) {
 	b.Refill(20)
 	assert.EqualValues(t, b.Available(), 10)
 }
+
+func BenchmarkBucket(b *testing.B) {
+	b.ReportAllocs()
+
+	bucket := bucket.New(uint64(b.N) * 1000000000000)
+	for i := 0; i < b.N; i++ {
+		bucket.Take()
+	}
+}

--- a/opt.go
+++ b/opt.go
@@ -1,4 +1,4 @@
-package ratelimiter
+package ratelimit
 
 type Opt func(r *RateLimiter)
 

--- a/ratelimiter_test.go
+++ b/ratelimiter_test.go
@@ -1,4 +1,4 @@
-package ratelimiter_test
+package ratelimit_test
 
 import (
 	"context"
@@ -8,11 +8,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	ratelimiter "github.com/vivangkumar/ratelimit"
+	"github.com/vivangkumar/ratelimit"
 )
 
 func TestRateLimiter_Add_TokensAvailable(t *testing.T) {
-	r, err := ratelimiter.New(100, 100, 1*time.Second)
+	r, err := ratelimit.New(100, 100, 1*time.Second)
 	assert.Nil(t, err)
 
 	assert.True(t, r.Add())
@@ -22,19 +22,19 @@ func TestRateLimiter_Add_TokensAvailable(t *testing.T) {
 }
 
 func TestRateLimiter_NewError(t *testing.T) {
-	_, err := ratelimiter.New(100, 0, 1*time.Second)
+	_, err := ratelimit.New(100, 0, 1*time.Second)
 	assert.Error(t, err)
 }
 
 func TestRateLimiter_AddN(t *testing.T) {
-	r, err := ratelimiter.New(10, 10, 1*time.Second)
+	r, err := ratelimit.New(10, 10, 1*time.Second)
 	assert.Nil(t, err)
 
 	assert.True(t, r.AddN(10))
 }
 
 func TestRateLimiter_Add_NoTokens(t *testing.T) {
-	r, err := ratelimiter.New(1, 1, 1*time.Second)
+	r, err := ratelimit.New(1, 1, 1*time.Second)
 	assert.Nil(t, err)
 
 	assert.True(t, r.Add())
@@ -42,7 +42,7 @@ func TestRateLimiter_Add_NoTokens(t *testing.T) {
 }
 
 func TestRateLimiter_RefreshToken(t *testing.T) {
-	r, err := ratelimiter.New(10, 10, 1*time.Second)
+	r, err := ratelimit.New(10, 10, 1*time.Second)
 	assert.Nil(t, err)
 
 	assert.True(t, r.AddN(10))
@@ -58,7 +58,7 @@ func TestRateLimiter_RefreshToken(t *testing.T) {
 }
 
 func TestRateLimiter_Wait(t *testing.T) {
-	r, err := ratelimiter.New(100, 10, 1*time.Second)
+	r, err := ratelimit.New(100, 10, 1*time.Second)
 	assert.Nil(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -72,7 +72,7 @@ func TestRateLimiter_Wait(t *testing.T) {
 }
 
 func TestRateLimiter_WaitN(t *testing.T) {
-	r, err := ratelimiter.New(100, 10, 1*time.Second)
+	r, err := ratelimit.New(100, 10, 1*time.Second)
 	assert.Nil(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -87,7 +87,7 @@ func TestRateLimiter_WaitN(t *testing.T) {
 }
 
 func TestRateLimiter_WaitN_ExceedsMaxTokens(t *testing.T) {
-	r, err := ratelimiter.New(100, 10, 1*time.Second)
+	r, err := ratelimit.New(100, 10, 1*time.Second)
 	assert.Nil(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -102,7 +102,7 @@ func TestRateLimiter_WaitN_ExceedsMaxTokens(t *testing.T) {
 }
 
 func TestRateLimiter_WaitCancel(t *testing.T) {
-	r, err := ratelimiter.New(100, 10, 1*time.Minute)
+	r, err := ratelimit.New(100, 10, 1*time.Minute)
 	assert.Nil(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
@@ -115,16 +115,25 @@ func TestRateLimiter_WaitCancel(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func BenchmarkRateLimiter(b *testing.B) {
+	b.ReportAllocs()
+
+	rl, _ := ratelimit.New(uint64(b.N), uint64(b.N), 1*time.Second)
+	for i := 0; i < b.N; i++ {
+		rl.Add()
+	}
+}
+
 func ExampleNew() {
 	// Create a new rate limiter instance.
-	_, err := ratelimiter.New(100, 10, time.Second)
+	_, err := ratelimit.New(100, 10, time.Second)
 	if err != nil {
 		fmt.Printf("context cancelled waiting for token: %s\n", err.Error())
 	}
 }
 
 func ExampleRateLimiter_Add() {
-	r, err := ratelimiter.New(100, 10, time.Second)
+	r, err := ratelimit.New(100, 10, time.Second)
 	if err != nil {
 		fmt.Printf("context cancelled waiting for token: %s\n", err.Error())
 	}
@@ -138,7 +147,7 @@ func ExampleRateLimiter_Add() {
 }
 
 func ExampleRateLimiter_AddN() {
-	r, err := ratelimiter.New(100, 10, time.Second)
+	r, err := ratelimit.New(100, 10, time.Second)
 	if err != nil {
 		fmt.Printf("error creating rate limiter: %s\n", err.Error())
 	}
@@ -152,7 +161,7 @@ func ExampleRateLimiter_AddN() {
 }
 
 func ExampleRateLimiter_Wait() {
-	r, err := ratelimiter.New(100, 10, time.Second)
+	r, err := ratelimit.New(100, 10, time.Second)
 	if err != nil {
 		fmt.Printf("error creating rate limiter: %s\n", err.Error())
 	}
@@ -169,7 +178,7 @@ func ExampleRateLimiter_Wait() {
 }
 
 func ExampleRateLimiter_WaitN() {
-	r, err := ratelimiter.New(100, 10, time.Second)
+	r, err := ratelimit.New(100, 10, time.Second)
 	if err != nil {
 		fmt.Printf("error creating rate limiter: %s\n", err.Error())
 	}
@@ -186,7 +195,7 @@ func ExampleRateLimiter_WaitN() {
 }
 
 func ExampleRateLimiter() {
-	r, err := ratelimiter.New(100, 10, 1*time.Second)
+	r, err := ratelimit.New(100, 10, 1*time.Second)
 	if err != nil {
 		fmt.Printf("error creating rate limiter: %s\n", err.Error())
 	}


### PR DESCRIPTION
## What?

- Rename package.
- Some aspects of the rate limiter were not thread safe, so fix them up.
- Add benchmarks.
- Benchmark in Gh actions.